### PR TITLE
Improve cost utilities and core prompt loading

### DIFF
--- a/quinn/agent/__init__.py
+++ b/quinn/agent/__init__.py
@@ -2,13 +2,21 @@
 
 from .cache import cache_response, get_cached_response
 from .core import calculate_cost, create_agent, generate_response
-from .cost import estimate_completion_cost, get_cost_per_token, get_model_cost_info
+from .cost import (
+    CompletionCostEstimate,
+    ModelCostInfo,
+    estimate_completion_cost,
+    get_cost_per_token,
+    get_model_cost_info,
+)
 from .metrics import track_response_metrics
 from .retry import retry_with_backoff
 from .validation import validate_message_for_ai
 from .versioning import get_current_prompt_version, load_system_prompt
 
 __all__ = [
+    "CompletionCostEstimate",
+    "ModelCostInfo",
     "cache_response",
     "calculate_cost",
     "create_agent",

--- a/quinn/agent/core.py
+++ b/quinn/agent/core.py
@@ -40,6 +40,9 @@ def _load_system_prompt() -> str:
         return "You are Quinn, a helpful AI assistant that guides users to solve their own problems by asking thoughtful questions rather than providing direct solutions."
 
 
+SYSTEM_PROMPT = _load_system_prompt()
+
+
 def _build_conversation_prompt(
     user_message: Message,
     conversation_history: list[Message],
@@ -188,7 +191,7 @@ async def create_agent(config: AgentConfig) -> Agent:
     # Create agent with configuration
     return Agent(
         model=config.model,
-        system_prompt=_load_system_prompt(),
+        system_prompt=SYSTEM_PROMPT,
         model_settings=model_settings,
         retries=config.max_retries,
     )

--- a/quinn/agent/core_test.py
+++ b/quinn/agent/core_test.py
@@ -14,6 +14,7 @@ from quinn.agent.core import (
     _build_conversation_prompt,
     _calculate_usage_metrics,
     _load_system_prompt,
+    SYSTEM_PROMPT,
     create_agent,
     generate_response,
 )
@@ -161,13 +162,13 @@ async def test_create_agent() -> None:
     """Test creating agent with configuration."""
     config = AgentConfig.o4mini()
     
-    with patch("quinn.agent.core._load_system_prompt", return_value="Test prompt"):
+    with patch("quinn.agent.core.SYSTEM_PROMPT", "Test prompt"):
         with patch("quinn.agent.core.Agent") as mock_agent_class:
             mock_agent = MagicMock()
             mock_agent_class.return_value = mock_agent
-            
+
             result = await create_agent(config)
-            
+
             assert result == mock_agent
             mock_agent_class.assert_called_once()
 

--- a/quinn/agent/cost_test.py
+++ b/quinn/agent/cost_test.py
@@ -7,6 +7,8 @@ from .cost import (
     estimate_completion_cost,
     get_cost_per_token,
     get_model_cost_info,
+    ModelCostInfo,
+    CompletionCostEstimate,
     get_supported_models,
 )
 
@@ -23,11 +25,9 @@ def test_get_model_cost_info() -> None:
     
     for model in test_models:
         cost_info = get_model_cost_info(model)
-        assert isinstance(cost_info, dict)
-        assert "input_cost_per_token" in cost_info
-        assert "output_cost_per_token" in cost_info
-        assert cost_info["input_cost_per_token"] >= 0.0
-        assert cost_info["output_cost_per_token"] >= 0.0
+        assert isinstance(cost_info, ModelCostInfo)
+        assert cost_info.input_cost_per_token >= 0.0
+        assert cost_info.output_cost_per_token >= 0.0
 
 
 def test_calculate_cost() -> None:
@@ -75,19 +75,12 @@ def test_estimate_completion_cost() -> None:
         max_tokens=100,
     )
     
-    assert isinstance(estimate, dict)
-    required_keys = [
-        "estimated_total_cost",
-        "estimated_input_tokens", 
-        "estimated_output_tokens",
-        "input_cost_per_token",
-        "output_cost_per_token",
-    ]
-    
-    for key in required_keys:
-        assert key in estimate
-        assert isinstance(estimate[key], (int, float))
-        assert estimate[key] >= 0.0
+    assert isinstance(estimate, CompletionCostEstimate)
+    assert estimate.estimated_total_cost >= 0.0
+    assert estimate.estimated_input_tokens >= 0
+    assert estimate.estimated_output_tokens >= 0
+    assert estimate.input_cost_per_token >= 0.0
+    assert estimate.output_cost_per_token >= 0.0
 
 
 def test_get_supported_models() -> None:
@@ -121,9 +114,9 @@ def test_free_model_pricing() -> None:
     """Test that free experimental models have zero cost."""
     free_model = "gemini-2.5-flash-exp"
     cost_info = get_model_cost_info(free_model)
-    
-    assert cost_info["input_cost_per_token"] == 0.0
-    assert cost_info["output_cost_per_token"] == 0.0
+
+    assert cost_info.input_cost_per_token == 0.0
+    assert cost_info.output_cost_per_token == 0.0
     
     # Cost calculation should be zero
     cost = calculate_cost(free_model, 1000, 500)
@@ -209,9 +202,9 @@ if __name__ == "__main__":
         max_tokens=200,
     )
     print(f"  Model: {model}")
-    print(f"  Estimated cost: ${estimate['estimated_total_cost']:.6f}")
-    print(f"  Input tokens: {estimate['estimated_input_tokens']}")
-    print(f"  Output tokens: {estimate['estimated_output_tokens']}")
+    print(f"  Estimated cost: ${estimate.estimated_total_cost:.6f}")
+    print(f"  Input tokens: {estimate.estimated_input_tokens}")
+    print(f"  Output tokens: {estimate.estimated_output_tokens}")
     
     print(f"\n🧪 Cost calculation tests completed!")
 


### PR DESCRIPTION
## Summary
- create reusable `ModelCostInfo` and `CompletionCostEstimate` named tuples
- load default system prompt once at import time
- update agent creation to use cached prompt
- adjust tests for structured return types

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_687f168df4ec8324a07d73fcdd2c6dc7