### PR TITLE
Replace DB try/except with assert-based checks

### DIFF
--- a/quinn/db/conversations.py
+++ b/quinn/db/conversations.py
@@ -44,100 +44,89 @@ class Conversations:
             conversation.user_id,
         )
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = """
-                    INSERT INTO conversations (id, user_id, created_at, updated_at, title, status, total_cost, message_count, metadata)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """
-                params = (
-                    conversation.id,
-                    conversation.user_id,
-                    int(conversation.created_at.timestamp()),
-                    int(conversation.updated_at.timestamp()),
-                    conversation.title,
-                    conversation.status,
-                    conversation.total_cost,
-                    conversation.message_count,
-                    json.dumps(conversation.metadata)
-                    if conversation.metadata
-                    else None,
-                )
-                logger.info("SQL: %s | Params: %s", sql.strip(), params)
-                cursor.execute(sql, params)
-                conn.commit()
-                logger.debug("Conversation created successfully: %s", conversation.id)
-        except Exception as e:
-            logger.error("Failed to create conversation %s: %s", conversation.id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                INSERT INTO conversations (id, user_id, created_at, updated_at, title, status, total_cost, message_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """
+            params = (
+                conversation.id,
+                conversation.user_id,
+                int(conversation.created_at.timestamp()),
+                int(conversation.updated_at.timestamp()),
+                conversation.title,
+                conversation.status,
+                conversation.total_cost,
+                conversation.message_count,
+                json.dumps(conversation.metadata) if conversation.metadata else None,
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, (
+                f"Failed to insert conversation {conversation.id}"
+            )
+            conn.commit()
+            logger.debug("Conversation created successfully: %s", conversation.id)
 
     @staticmethod
     def get_by_id(conversation_id: str) -> DbConversation | None:
         """Retrieves a conversation by its ID."""
         logger.debug("Retrieving conversation by ID: %s", conversation_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "SELECT * FROM conversations WHERE id = ?"
-                params = (conversation_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                row = cursor.fetchone()
-                if row:
-                    logger.debug("Conversation found: %s", conversation_id)
-                    return DbConversation(
-                        conversation_id=row[0],
-                        user_id=row[1],
-                        created_at=datetime.fromtimestamp(row[2], UTC),
-                        updated_at=datetime.fromtimestamp(row[3], UTC),
-                        title=row[4],
-                        status=row[5],
-                        total_cost=row[6],
-                        message_count=row[7],
-                        metadata=json.loads(row[8]) if row[8] else None,
-                    )
-                logger.debug("Conversation not found: %s", conversation_id)
-                return None
-        except Exception as e:
-            logger.error("Failed to retrieve conversation {conversation_id}: %s", e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM conversations WHERE id = ?"
+            params = (conversation_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            row = cursor.fetchone()
+            if row:
+                logger.debug("Conversation found: %s", conversation_id)
+                return DbConversation(
+                    conversation_id=row[0],
+                    user_id=row[1],
+                    created_at=datetime.fromtimestamp(row[2], UTC),
+                    updated_at=datetime.fromtimestamp(row[3], UTC),
+                    title=row[4],
+                    status=row[5],
+                    total_cost=row[6],
+                    message_count=row[7],
+                    metadata=json.loads(row[8]) if row[8] else None,
+                )
+            logger.debug("Conversation not found: %s", conversation_id)
+            return None
 
     @staticmethod
     def get_by_user(user_id: str) -> list[DbConversation]:
         """Retrieves all conversations for a given user."""
         logger.debug("Retrieving conversations for user: %s", user_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "SELECT * FROM conversations WHERE user_id = ?"
-                params = (user_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                rows = cursor.fetchall()
-                conversations = [
-                    DbConversation(
-                        conversation_id=row[0],
-                        user_id=row[1],
-                        created_at=datetime.fromtimestamp(row[2], UTC),
-                        updated_at=datetime.fromtimestamp(row[3], UTC),
-                        title=row[4],
-                        status=row[5],
-                        total_cost=row[6],
-                        message_count=row[7],
-                        metadata=json.loads(row[8]) if row[8] else None,
-                    )
-                    for row in rows
-                ]
-                logger.debug(
-                    "Found {len(conversations)} conversations for user %s", user_id
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM conversations WHERE user_id = ?"
+            params = (user_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+            conversations = [
+                DbConversation(
+                    conversation_id=row[0],
+                    user_id=row[1],
+                    created_at=datetime.fromtimestamp(row[2], UTC),
+                    updated_at=datetime.fromtimestamp(row[3], UTC),
+                    title=row[4],
+                    status=row[5],
+                    total_cost=row[6],
+                    message_count=row[7],
+                    metadata=json.loads(row[8]) if row[8] else None,
                 )
-                return conversations
-        except Exception as e:
-            logger.error("Failed to retrieve conversations for user {user_id}: %s", e)
-            raise
+                for row in rows
+            ]
+            logger.debug(
+                "Found {len(conversations)} conversations for user %s", user_id
+            )
+            return conversations
 
     @staticmethod
     def update(conversation: DbConversation) -> None:
@@ -145,55 +134,44 @@ class Conversations:
         conversation.updated_at = datetime.now(UTC)
         logger.info("Updating conversation: %s", conversation.id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = """
-                    UPDATE conversations
-                    SET updated_at = ?, title = ?, status = ?, total_cost = ?, message_count = ?, metadata = ?
-                    WHERE id = ?
-                    """
-                params = (
-                    int(conversation.updated_at.timestamp()),
-                    conversation.title,
-                    conversation.status,
-                    conversation.total_cost,
-                    conversation.message_count,
-                    json.dumps(conversation.metadata)
-                    if conversation.metadata
-                    else None,
-                    conversation.id,
-                )
-                logger.info("SQL: %s | Params: %s", sql.strip(), params)
-                cursor.execute(sql, params)
-                conn.commit()
-                logger.debug("Conversation updated successfully: %s", conversation.id)
-        except Exception as e:
-            logger.error("Failed to update conversation {conversation.id}: %s", e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                UPDATE conversations
+                SET updated_at = ?, title = ?, status = ?, total_cost = ?, message_count = ?, metadata = ?
+                WHERE id = ?
+                """
+            params = (
+                int(conversation.updated_at.timestamp()),
+                conversation.title,
+                conversation.status,
+                conversation.total_cost,
+                conversation.message_count,
+                json.dumps(conversation.metadata) if conversation.metadata else None,
+                conversation.id,
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, (
+                f"Failed to update conversation {conversation.id}"
+            )
+            conn.commit()
+            logger.debug("Conversation updated successfully: %s", conversation.id)
 
     @staticmethod
     def delete(conversation_id: str) -> None:
         """Deletes a conversation from the database."""
         logger.info("Deleting conversation: %s", conversation_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "DELETE FROM conversations WHERE id = ?"
-                params = (conversation_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                rows_affected = cursor.rowcount
-                conn.commit()
-                if rows_affected > 0:
-                    logger.debug(
-                        "Conversation deleted successfully: %s", conversation_id
-                    )
-                else:
-                    logger.warning(
-                        "No conversation found to delete: %s", conversation_id
-                    )
-        except Exception as e:
-            logger.error("Failed to delete conversation {conversation_id}: %s", e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "DELETE FROM conversations WHERE id = ?"
+            params = (conversation_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            rows_affected = cursor.rowcount
+            conn.commit()
+            if rows_affected > 0:
+                logger.debug("Conversation deleted successfully: %s", conversation_id)
+            else:
+                logger.warning("No conversation found to delete: %s", conversation_id)

--- a/quinn/db/database.py
+++ b/quinn/db/database.py
@@ -9,59 +9,35 @@ logger = logging.getLogger(__name__)
 DATABASE_FILE = "quinn.db"
 
 
-def _log_database_error(error: Exception, context: str) -> None:
-    """Log database errors appropriately based on error type."""
-    if "already exists" in str(error):
-        logger.debug("%s: %s", context, error)
-    else:
-        logger.error("%s: %s", context, error)
-
-
 @contextmanager
 def get_db_connection() -> Generator[sqlite3.Connection]:
     """Context manager to handle database connections."""
     logger.debug("Opening database connection to %s", DATABASE_FILE)
-    conn = None
+    conn = sqlite3.connect(DATABASE_FILE)
+    assert conn is not None, f"Failed to connect to {DATABASE_FILE}"
+
+    # Enable foreign key constraints
+    pragma_sql = "PRAGMA foreign_keys = ON"
+    logger.info("SQL: %s", pragma_sql)
+    conn.execute(pragma_sql)
+
     try:
-        conn = sqlite3.connect(DATABASE_FILE)
-        # Enable foreign key constraints
-        pragma_sql = "PRAGMA foreign_keys = ON"
-        logger.info("SQL: %s", pragma_sql)
-        conn.execute(pragma_sql)
-        try:
-            yield conn
-            logger.debug("Database connection successful")
-        except Exception as e:
-            _log_database_error(e, "Database connection error")
-            conn.rollback()
-            raise
-    except Exception as e:
-        _log_database_error(e, "Database setup error")
-        raise
+        yield conn
+        logger.debug("Database connection successful")
     finally:
-        if conn:
-            try:
-                conn.close()
-                logger.debug("Database connection closed")
-            except Exception as close_error:
-                logger.warning("Error closing database connection: %s", close_error)
+        conn.close()
+        logger.debug("Database connection closed")
 
 
 def create_tables() -> None:
-    """Creates the database tables based on the schema.sql file."""
+    """Create database tables based on the schema.sql file."""
     schema_path = Path("quinn/db/schema.sql")
     logger.info("Creating database tables from schema: %s", schema_path)
 
-    try:
-        with get_db_connection() as conn, schema_path.open() as f:
-            schema_sql = f.read()
-            logger.info("SQL: %s", schema_sql)
-            conn.executescript(schema_sql)
-            logger.info("Database tables created successfully")
-    except Exception as e:
-        # Only log as error if it's not a "table already exists" error
-        if "already exists" in str(e):
-            logger.debug("Database tables already exist, skipping creation")
-        else:
-            logger.error("Failed to create database tables: %s", e)
-            raise
+    assert schema_path.exists(), f"Missing schema file at {schema_path}"
+
+    with get_db_connection() as conn, schema_path.open() as f:
+        schema_sql = f.read()
+        logger.info("SQL: %s", schema_sql)
+        conn.executescript(schema_sql)
+        logger.info("Database tables created successfully")

--- a/quinn/db/messages.py
+++ b/quinn/db/messages.py
@@ -18,117 +18,98 @@ class Messages:
             message.conversation_id,
         )
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = """
-                    INSERT INTO messages (id, conversation_id, user_id, created_at, last_updated_at, system_prompt, user_content, assistant_content, metadata)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """
-                params = (
-                    message.id,
-                    message.conversation_id,
-                    user_id,
-                    int(message.created_at.timestamp()),
-                    int(message.last_updated_at.timestamp()),
-                    message.system_prompt,
-                    message.user_content,
-                    message.assistant_content,
-                    json.dumps(message.metadata.model_dump())
-                    if message.metadata
-                    else None,
-                )
-                logger.info("SQL: %s | Params: %s", sql.strip(), params)
-                cursor.execute(sql, params)
-                conn.commit()
-                logger.debug("Message created successfully: %s", message.id)
-        except Exception as e:
-            logger.error("Failed to create message %s: %s", message.id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                INSERT INTO messages (id, conversation_id, user_id, created_at, last_updated_at, system_prompt, user_content, assistant_content, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """
+            params = (
+                message.id,
+                message.conversation_id,
+                user_id,
+                int(message.created_at.timestamp()),
+                int(message.last_updated_at.timestamp()),
+                message.system_prompt,
+                message.user_content,
+                message.assistant_content,
+                json.dumps(message.metadata.model_dump()) if message.metadata else None,
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, f"Failed to insert message {message.id}"
+            conn.commit()
+            logger.debug("Message created successfully: %s", message.id)
 
     @staticmethod
     def get_by_id(message_id: str) -> Message | None:
         """Retrieves a message by its ID."""
         logger.debug("Retrieving message by ID: %s", message_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "SELECT * FROM messages WHERE id = ?"
-                params = (message_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                row = cursor.fetchone()
-                if row:
-                    logger.debug("Message found: %s", message_id)
-                    # Convert from database format to models format
-                    metadata = None
-                    if row[8]:
-                        metadata_dict = json.loads(row[8])
-                        metadata = MessageMetrics(**metadata_dict)
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM messages WHERE id = ?"
+            params = (message_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            row = cursor.fetchone()
+            if row:
+                logger.debug("Message found: %s", message_id)
+                metadata = None
+                if row[8]:
+                    metadata_dict = json.loads(row[8])
+                    metadata = MessageMetrics(**metadata_dict)
 
-                    return Message(
-                        id=row[0],
-                        conversation_id=row[1],
-                        created_at=datetime.fromtimestamp(row[3], UTC),
-                        last_updated_at=datetime.fromtimestamp(row[4], UTC),
-                        system_prompt=row[5],
-                        user_content=row[6],
-                        assistant_content=row[7],
-                        metadata=metadata,
-                    )
-                logger.debug("Message not found: %s", message_id)
-                return None
-        except Exception as e:
-            logger.error("Failed to retrieve message %s: %s", message_id, e)
-            raise
+                return Message(
+                    id=row[0],
+                    conversation_id=row[1],
+                    created_at=datetime.fromtimestamp(row[3], UTC),
+                    last_updated_at=datetime.fromtimestamp(row[4], UTC),
+                    system_prompt=row[5],
+                    user_content=row[6],
+                    assistant_content=row[7],
+                    metadata=metadata,
+                )
+            logger.debug("Message not found: %s", message_id)
+            return None
 
     @staticmethod
     def get_by_conversation(conversation_id: str) -> list[Message]:
         """Retrieves all messages for a given conversation."""
         logger.debug("Retrieving messages for conversation: %s", conversation_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at ASC"
-                params = (conversation_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                rows = cursor.fetchall()
-                messages = []
-                for row in rows:
-                    # Convert from database format to models format
-                    metadata = None
-                    if row[8]:
-                        metadata_dict = json.loads(row[8])
-                        metadata = MessageMetrics(**metadata_dict)
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at ASC"
+            params = (conversation_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+            messages = []
+            for row in rows:
+                metadata = None
+                if row[8]:
+                    metadata_dict = json.loads(row[8])
+                    metadata = MessageMetrics(**metadata_dict)
 
-                    message = Message(
-                        id=row[0],
-                        conversation_id=row[1],
-                        created_at=datetime.fromtimestamp(row[3], UTC),
-                        last_updated_at=datetime.fromtimestamp(row[4], UTC),
-                        system_prompt=row[5],
-                        user_content=row[6],
-                        assistant_content=row[7],
-                        metadata=metadata,
-                    )
-                    messages.append(message)
-
-                logger.debug(
-                    "Found %d messages for conversation %s",
-                    len(messages),
-                    conversation_id,
+                message = Message(
+                    id=row[0],
+                    conversation_id=row[1],
+                    created_at=datetime.fromtimestamp(row[3], UTC),
+                    last_updated_at=datetime.fromtimestamp(row[4], UTC),
+                    system_prompt=row[5],
+                    user_content=row[6],
+                    assistant_content=row[7],
+                    metadata=metadata,
                 )
-                return messages
-        except Exception as e:
-            logger.error(
-                "Failed to retrieve messages for conversation %s: %s",
+                messages.append(message)
+
+            logger.debug(
+                "Found %d messages for conversation %s",
+                len(messages),
                 conversation_id,
-                e,
             )
-            raise
+            return messages
 
     @staticmethod
     def update(message: Message) -> None:
@@ -137,50 +118,41 @@ class Messages:
         message.last_updated_at = datetime.now(UTC)
         logger.info("Updating message: %s", message.id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = """
-                    UPDATE messages
-                    SET last_updated_at = ?, system_prompt = ?, user_content = ?, assistant_content = ?, metadata = ?
-                    WHERE id = ?
-                    """
-                params = (
-                    int(message.last_updated_at.timestamp()),
-                    message.system_prompt,
-                    message.user_content,
-                    message.assistant_content,
-                    json.dumps(message.metadata.model_dump())
-                    if message.metadata
-                    else None,
-                    message.id,
-                )
-                logger.info("SQL: %s | Params: %s", sql.strip(), params)
-                cursor.execute(sql, params)
-                conn.commit()
-                logger.debug("Message updated successfully: %s", message.id)
-        except Exception as e:
-            logger.error("Failed to update message %s: %s", message.id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                UPDATE messages
+                SET last_updated_at = ?, system_prompt = ?, user_content = ?, assistant_content = ?, metadata = ?
+                WHERE id = ?
+                """
+            params = (
+                int(message.last_updated_at.timestamp()),
+                message.system_prompt,
+                message.user_content,
+                message.assistant_content,
+                json.dumps(message.metadata.model_dump()) if message.metadata else None,
+                message.id,
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, f"Failed to update message {message.id}"
+            conn.commit()
+            logger.debug("Message updated successfully: %s", message.id)
 
     @staticmethod
     def delete(message_id: str) -> None:
         """Deletes a message from the database."""
         logger.info("Deleting message: %s", message_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "DELETE FROM messages WHERE id = ?"
-                params = (message_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                rows_affected = cursor.rowcount
-                conn.commit()
-                if rows_affected > 0:
-                    logger.debug("Message deleted successfully: %s", message_id)
-                else:
-                    logger.warning("No message found to delete: %s", message_id)
-        except Exception as e:
-            logger.error("Failed to delete message {message_id}: %s", e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "DELETE FROM messages WHERE id = ?"
+            params = (message_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            rows_affected = cursor.rowcount
+            conn.commit()
+            if rows_affected > 0:
+                logger.debug("Message deleted successfully: %s", message_id)
+            else:
+                logger.warning("No message found to delete: %s", message_id)

--- a/quinn/db/users.py
+++ b/quinn/db/users.py
@@ -16,87 +16,76 @@ class Users:
             "Creating user: id=%s, emails=%s", user.id, len(user.email_addresses)
         )
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = """
-                    INSERT INTO users (id, created_at, updated_at, name, email_addresses, settings)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """
-                params = (
-                    user.id,
-                    int(user.created_at.timestamp()),
-                    int(user.updated_at.timestamp()),
-                    user.name,
-                    json.dumps(user.email_addresses),
-                    json.dumps(user.settings) if user.settings else None,
-                )
-                logger.info("SQL: %s | Params: %s", sql.strip(), params)
-                cursor.execute(sql, params)
-                conn.commit()
-                logger.debug("User created successfully: %s", user.id)
-        except Exception as e:
-            logger.error("Failed to create user %s: %s", user.id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                INSERT INTO users (id, created_at, updated_at, name, email_addresses, settings)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """
+            params = (
+                user.id,
+                int(user.created_at.timestamp()),
+                int(user.updated_at.timestamp()),
+                user.name,
+                json.dumps(user.email_addresses),
+                json.dumps(user.settings) if user.settings else None,
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, f"Failed to insert user {user.id}"
+            conn.commit()
+            logger.debug("User created successfully: %s", user.id)
 
     @staticmethod
     def get_by_id(user_id: str) -> User | None:
         """Retrieves a user by their ID."""
         logger.debug("Retrieving user by ID: %s", user_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "SELECT * FROM users WHERE id = ?"
-                params = (user_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                row = cursor.fetchone()
-                if row:
-                    logger.debug("User found: %s", user_id)
-                    return User(
-                        id=row[0],
-                        created_at=datetime.fromtimestamp(row[1], UTC),
-                        updated_at=datetime.fromtimestamp(row[2], UTC),
-                        name=row[3],
-                        email_addresses=json.loads(row[4]),
-                        settings=json.loads(row[5]) if row[5] else None,
-                    )
-                logger.debug("User not found: %s", user_id)
-                return None
-        except Exception as e:
-            logger.error("Failed to retrieve user %s: %s", user_id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM users WHERE id = ?"
+            params = (user_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            row = cursor.fetchone()
+            if row:
+                logger.debug("User found: %s", user_id)
+                return User(
+                    id=row[0],
+                    created_at=datetime.fromtimestamp(row[1], UTC),
+                    updated_at=datetime.fromtimestamp(row[2], UTC),
+                    name=row[3],
+                    email_addresses=json.loads(row[4]),
+                    settings=json.loads(row[5]) if row[5] else None,
+                )
+            logger.debug("User not found: %s", user_id)
+            return None
 
     @staticmethod
     def get_by_email(email: str) -> User | None:
         """Retrieves a user by any of their email addresses."""
         logger.debug("Retrieving user by email: %s", email)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "SELECT * FROM users"
-                logger.info("SQL: %s", sql)
-                cursor.execute(sql)
-                rows = cursor.fetchall()
-                for row in rows:
-                    email_addresses = json.loads(row[4])
-                    if email in email_addresses:
-                        logger.debug("User found by email %s: %s", email, row[0])
-                        return User(
-                            id=row[0],
-                            created_at=datetime.fromtimestamp(row[1], UTC),
-                            updated_at=datetime.fromtimestamp(row[2], UTC),
-                            name=row[3],
-                            email_addresses=email_addresses,
-                            settings=json.loads(row[5]) if row[5] else None,
-                        )
-                logger.debug("No user found with email: %s", email)
-                return None
-        except Exception as e:
-            logger.error("Failed to retrieve user by email %s: %s", email, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM users"
+            logger.info("SQL: %s", sql)
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+            for row in rows:
+                email_addresses = json.loads(row[4])
+                if email in email_addresses:
+                    logger.debug("User found by email %s: %s", email, row[0])
+                    return User(
+                        id=row[0],
+                        created_at=datetime.fromtimestamp(row[1], UTC),
+                        updated_at=datetime.fromtimestamp(row[2], UTC),
+                        name=row[3],
+                        email_addresses=email_addresses,
+                        settings=json.loads(row[5]) if row[5] else None,
+                    )
+            logger.debug("No user found with email: %s", email)
+            return None
 
     @staticmethod
     def update(user: User) -> None:
@@ -104,28 +93,25 @@ class Users:
         user.updated_at = datetime.now(UTC)
         logger.info("Updating user: %s", user.id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = """
-                    UPDATE users
-                    SET updated_at = ?, name = ?, email_addresses = ?, settings = ?
-                    WHERE id = ?
-                    """
-                params = (
-                    int(user.updated_at.timestamp()),
-                    user.name,
-                    json.dumps(user.email_addresses),
-                    json.dumps(user.settings) if user.settings else None,
-                    user.id,
-                )
-                logger.info("SQL: %s | Params: %s", sql.strip(), params)
-                cursor.execute(sql, params)
-                conn.commit()
-                logger.debug("User updated successfully: %s", user.id)
-        except Exception as e:
-            logger.error("Failed to update user %s: %s", user.id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                UPDATE users
+                SET updated_at = ?, name = ?, email_addresses = ?, settings = ?
+                WHERE id = ?
+                """
+            params = (
+                int(user.updated_at.timestamp()),
+                user.name,
+                json.dumps(user.email_addresses),
+                json.dumps(user.settings) if user.settings else None,
+                user.id,
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, f"Failed to update user {user.id}"
+            conn.commit()
+            logger.debug("User updated successfully: %s", user.id)
 
     @staticmethod
     def add_alternative_email(user_id: str, email: str) -> bool:
@@ -135,46 +121,36 @@ class Users:
         """
         logger.info("Adding alternative email %s to user %s", email, user_id)
 
-        try:
-            user = Users.get_by_id(user_id)
-            if not user:
-                logger.warning("User not found for adding email: %s", user_id)
-                return False
+        user = Users.get_by_id(user_id)
+        if not user:
+            logger.warning("User not found for adding email: %s", user_id)
+            return False
 
-            if email in user.email_addresses:
-                logger.debug("Email %s already exists for user %s", email, user_id)
-                return False  # Email already exists
+        if email in user.email_addresses:
+            logger.debug("Email %s already exists for user %s", email, user_id)
+            return False  # Email already exists
 
-            user.email_addresses.append(email)
-            Users.update(user)
-            logger.debug(
-                "Alternative email %s added successfully to user %s", email, user_id
-            )
-            return True
-        except Exception as e:
-            logger.error(
-                "Failed to add alternative email %s to user %s: %s", email, user_id, e
-            )
-            raise
+        user.email_addresses.append(email)
+        Users.update(user)
+        logger.debug(
+            "Alternative email %s added successfully to user %s", email, user_id
+        )
+        return True
 
     @staticmethod
     def delete(user_id: str) -> None:
         """Deletes a user from the database."""
         logger.info("Deleting user: %s", user_id)
 
-        try:
-            with get_db_connection() as conn:
-                cursor = conn.cursor()
-                sql = "DELETE FROM users WHERE id = ?"
-                params = (user_id,)
-                logger.info("SQL: %s | Params: %s", sql, params)
-                cursor.execute(sql, params)
-                rows_affected = cursor.rowcount
-                conn.commit()
-                if rows_affected > 0:
-                    logger.debug("User deleted successfully: %s", user_id)
-                else:
-                    logger.warning("No user found to delete: %s", user_id)
-        except Exception as e:
-            logger.error("Failed to delete user %s: %s", user_id, e)
-            raise
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "DELETE FROM users WHERE id = ?"
+            params = (user_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            rows_affected = cursor.rowcount
+            conn.commit()
+            if rows_affected > 0:
+                logger.debug("User deleted successfully: %s", user_id)
+            else:
+                logger.warning("No user found to delete: %s", user_id)


### PR DESCRIPTION
## Summary
- refactor database helpers to use `assert` rather than try/except
- simplify CRUD helpers for conversations, messages and users
- ensure deletes log a warning instead of raising

## Testing
- `uv run ruff check quinn/db/database.py quinn/db/conversations.py quinn/db/messages.py quinn/db/users.py`
- `uv run ty check quinn/db/database.py quinn/db/conversations.py quinn/db/messages.py quinn/db/users.py`
- `uv run pytest -vv quinn/db/conversations_test.py quinn/db/messages_test.py quinn/db/users_test.py quinn/db/database_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68829d1354a483248189084a3dda8b94