### PR TITLE
Add email support with storage and utilities

### DIFF
--- a/quinn/cli.py
+++ b/quinn/cli.py
@@ -18,7 +18,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 
 from quinn.agent.core import generate_response
-from quinn.db.conversations import Conversations, DbConversation
+from quinn.db.conversations import Conversations, ConversationStore
 from quinn.db.database import create_tables
 from quinn.db.messages import Messages
 from quinn.db.users import Users
@@ -139,7 +139,7 @@ async def _generate_and_save_response(
                 if len(user_content) > TITLE_MAX_LENGTH
                 else user_content
             )
-            db_conversation = DbConversation(
+            db_conversation = ConversationStore(
                 conversation_id=conversation_id,
                 user_id="cli-user",  # Fixed user for CLI usage
                 title=title,
@@ -224,7 +224,7 @@ def _list_conversations() -> None:
     console.print(table)
 
 
-def _get_conversation_by_index(index: int) -> DbConversation | None:
+def _get_conversation_by_index(index: int) -> ConversationStore | None:
     """Get conversation by 1-based index (as shown in list)."""
     conversations = Conversations.get_by_user("cli-user")
     if not conversations:
@@ -239,7 +239,7 @@ def _get_conversation_by_index(index: int) -> DbConversation | None:
     return conversations[index - 1]  # Convert to 0-based index
 
 
-def _get_most_recent_conversation() -> DbConversation | None:
+def _get_most_recent_conversation() -> ConversationStore | None:
     """Get the most recently updated conversation."""
     conversations = Conversations.get_by_user("cli-user")
     if not conversations:
@@ -400,7 +400,7 @@ def _handle_new_conversation(
 
 
 def _handle_continue_recent_conversation(
-    recent_conversation: DbConversation, model: str
+    recent_conversation: ConversationStore, model: str
 ) -> None:
     """Handle continuing the most recent conversation."""
     # Use editor to get continuation input

--- a/quinn/db/conftest.py
+++ b/quinn/db/conftest.py
@@ -49,6 +49,7 @@ def clean_db(temp_db: Path) -> Generator[Path]:
         patch("quinn.db.database.DATABASE_FILE", str(temp_db)),
         get_db_connection() as conn,
     ):
+        conn.execute("DELETE FROM emails")
         conn.execute("DELETE FROM messages")
         conn.execute("DELETE FROM conversations")
         conn.execute("DELETE FROM users")

--- a/quinn/db/conversations.py
+++ b/quinn/db/conversations.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 # Database representation of a conversation (simple data class for DB operations)
-class DbConversation:
+class ConversationStore:
     """Database representation of a conversation for DB operations only."""
 
     def __init__(
@@ -36,7 +36,7 @@ class DbConversation:
 
 class Conversations:
     @staticmethod
-    def create(conversation: DbConversation) -> None:
+    def create(conversation: ConversationStore) -> None:
         """Creates a new conversation in the database."""
         logger.info(
             "Creating conversation: id=%s, user_id=%s",
@@ -70,7 +70,7 @@ class Conversations:
             logger.debug("Conversation created successfully: %s", conversation.id)
 
     @staticmethod
-    def get_by_id(conversation_id: str) -> DbConversation | None:
+    def get_by_id(conversation_id: str) -> ConversationStore | None:
         """Retrieves a conversation by its ID."""
         logger.debug("Retrieving conversation by ID: %s", conversation_id)
 
@@ -83,7 +83,7 @@ class Conversations:
             row = cursor.fetchone()
             if row:
                 logger.debug("Conversation found: %s", conversation_id)
-                return DbConversation(
+                return ConversationStore(
                     conversation_id=row[0],
                     user_id=row[1],
                     created_at=datetime.fromtimestamp(row[2], UTC),
@@ -98,7 +98,7 @@ class Conversations:
             return None
 
     @staticmethod
-    def get_by_user(user_id: str) -> list[DbConversation]:
+    def get_by_user(user_id: str) -> list[ConversationStore]:
         """Retrieves all conversations for a given user."""
         logger.debug("Retrieving conversations for user: %s", user_id)
 
@@ -110,7 +110,7 @@ class Conversations:
             cursor.execute(sql, params)
             rows = cursor.fetchall()
             conversations = [
-                DbConversation(
+                ConversationStore(
                     conversation_id=row[0],
                     user_id=row[1],
                     created_at=datetime.fromtimestamp(row[2], UTC),
@@ -129,7 +129,7 @@ class Conversations:
             return conversations
 
     @staticmethod
-    def update(conversation: DbConversation) -> None:
+    def update(conversation: ConversationStore) -> None:
         """Updates an existing conversation."""
         conversation.updated_at = datetime.now(UTC)
         logger.info("Updating conversation: %s", conversation.id)

--- a/quinn/db/conversations_test.py
+++ b/quinn/db/conversations_test.py
@@ -5,16 +5,16 @@ from unittest.mock import patch
 
 import pytest
 
-from quinn.db.conversations import DbConversation, Conversations
+from quinn.db.conversations import Conversations, ConversationStore
 
 
 def test_conversation_model_creation():
-    """Test DbConversation model creation with required fields."""
+    """Test ConversationStore model creation with required fields."""
     conversation_id = str(uuid.uuid4())
     user_id = str(uuid.uuid4())
-    
-    conversation = DbConversation(conversation_id=conversation_id, user_id=user_id)
-    
+
+    conversation = ConversationStore(conversation_id=conversation_id, user_id=user_id)
+
     assert conversation.id == conversation_id
     assert conversation.user_id == user_id
     assert conversation.title is None
@@ -25,20 +25,20 @@ def test_conversation_model_creation():
 
 
 def test_conversation_model_with_optional_fields():
-    """Test DbConversation model with optional fields."""
+    """Test ConversationStore model with optional fields."""
     conversation_id = str(uuid.uuid4())
     user_id = str(uuid.uuid4())
-    
-    conversation = DbConversation(
+
+    conversation = ConversationStore(
         conversation_id=conversation_id,
         user_id=user_id,
         title="Test Conversation",
         status="archived",
         total_cost=1.5,
         message_count=5,
-        metadata={"test": "data"}
+        metadata={"test": "data"},
     )
-    
+
     assert conversation.title == "Test Conversation"
     assert conversation.status == "archived"
     assert conversation.total_cost == 1.5
@@ -51,16 +51,16 @@ def test_conversations_create(setup_test_data):
     # Create a new conversation with unique ID
     new_conversation_id = str(uuid.uuid4())
     user_id = setup_test_data["test_user_data"]["id"]
-    
-    conversation = DbConversation(
+
+    conversation = ConversationStore(
         conversation_id=new_conversation_id,
         user_id=user_id,
         title="New Test Conversation",
     )
-    
+
     with patch("quinn.db.database.DATABASE_FILE", str(setup_test_data["db_file"])):
         Conversations.create(conversation)
-        
+
         # Verify conversation was created
         retrieved_conversation = Conversations.get_by_id(new_conversation_id)
         assert retrieved_conversation is not None
@@ -73,7 +73,7 @@ def test_conversations_get_by_id(setup_test_data):
     """Test retrieving a conversation by ID."""
     # Use the existing conversation from setup_test_data
     test_conversation_data = setup_test_data["test_conversation_data"]
-    
+
     with patch("quinn.db.database.DATABASE_FILE", str(setup_test_data["db_file"])):
         retrieved_conversation = Conversations.get_by_id(test_conversation_data["id"])
         assert retrieved_conversation is not None
@@ -86,25 +86,25 @@ def test_conversations_get_by_user(setup_test_data):
     """Test retrieving conversations by user."""
     # Use existing test user to satisfy foreign key constraints
     user_id = setup_test_data["test_user_data"]["id"]
-    
-    conversation1 = DbConversation(
+
+    conversation1 = ConversationStore(
         conversation_id=str(uuid.uuid4()),
         user_id=user_id,
         title="First conversation",
     )
-    conversation2 = DbConversation(
+    conversation2 = ConversationStore(
         conversation_id=str(uuid.uuid4()),
         user_id=user_id,
         title="Second conversation",
     )
-    
+
     with patch("quinn.db.database.DATABASE_FILE", str(setup_test_data["db_file"])):
         Conversations.create(conversation1)
         Conversations.create(conversation2)
-        
+
         # Retrieve conversations for user (includes existing test conversation)
         retrieved_conversations = Conversations.get_by_user(user_id)
-        
+
         # Should have 3 conversations (2 new + 1 from setup_test_data)
         assert len(retrieved_conversations) == 3
         conversation_titles = [c.title for c in retrieved_conversations]
@@ -117,19 +117,19 @@ def test_conversations_update(setup_test_data):
     """Test updating a conversation."""
     # Use the existing conversation from setup_test_data
     test_conversation_data = setup_test_data["test_conversation_data"]
-    
+
     with patch("quinn.db.database.DATABASE_FILE", str(setup_test_data["db_file"])):
         # Get the existing conversation
         conversation = Conversations.get_by_id(test_conversation_data["id"])
         assert conversation is not None
-        
+
         # Update the conversation
         conversation.title = "Updated title"
         conversation.status = "completed"
         conversation.total_cost = 2.5
-        
+
         Conversations.update(conversation)
-        
+
         # Verify the update
         retrieved_conversation = Conversations.get_by_id(test_conversation_data["id"])
         assert retrieved_conversation is not None
@@ -143,23 +143,23 @@ def test_conversations_delete(setup_test_data):
     # Create a new conversation to delete
     new_conversation_id = str(uuid.uuid4())
     user_id = setup_test_data["test_user_data"]["id"]
-    
-    conversation = DbConversation(
+
+    conversation = ConversationStore(
         conversation_id=new_conversation_id,
         user_id=user_id,
         title="Conversation to delete",
     )
-    
+
     with patch("quinn.db.database.DATABASE_FILE", str(setup_test_data["db_file"])):
         Conversations.create(conversation)
-        
+
         # Verify conversation exists
         retrieved_conversation = Conversations.get_by_id(new_conversation_id)
         assert retrieved_conversation is not None
-        
+
         # Delete the conversation
         Conversations.delete(new_conversation_id)
-        
+
         # Verify deletion
         deleted_conversation = Conversations.get_by_id(new_conversation_id)
         assert deleted_conversation is None
@@ -168,26 +168,27 @@ def test_conversations_delete(setup_test_data):
 def test_conversations_error_handling():
     """Test error handling in conversation operations."""
     conversation_id = str(uuid.uuid4())
-    
-    conversation = DbConversation(
-        conversation_id=conversation_id,
-        user_id="test-user",
-        title="Test conversation"
+
+    conversation = ConversationStore(
+        conversation_id=conversation_id, user_id="test-user", title="Test conversation"
     )
-    
+
     # Test database connection error
-    with patch("quinn.db.conversations.get_db_connection", side_effect=Exception("Database error")):
+    with patch(
+        "quinn.db.conversations.get_db_connection",
+        side_effect=Exception("Database error"),
+    ):
         with pytest.raises(Exception, match="Database error"):
             Conversations.create(conversation)
-        
+
         with pytest.raises(Exception, match="Database error"):
             Conversations.get_by_id(conversation_id)
-        
+
         with pytest.raises(Exception, match="Database error"):
             Conversations.get_by_user("test-user")
-        
+
         with pytest.raises(Exception, match="Database error"):
             Conversations.update(conversation)
-        
+
         with pytest.raises(Exception, match="Database error"):
             Conversations.delete(conversation_id)

--- a/quinn/db/emails.py
+++ b/quinn/db/emails.py
@@ -1,0 +1,97 @@
+"""Database access for storing email messages."""
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from quinn.db.database import get_db_connection
+from quinn.models.email import EmailDirection, EmailMessage
+
+logger = logging.getLogger(__name__)
+
+
+class EmailStore:
+    """CRUD helpers for the ``emails`` table."""
+
+    @staticmethod
+    def create(email: EmailMessage) -> None:
+        """Insert an email into the database."""
+        logger.info(
+            "Storing email: id=%s conversation_id=%s direction=%s",
+            email.id,
+            email.conversation_id,
+            email.direction.value,
+        )
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = """
+                INSERT INTO emails (
+                    id, conversation_id, created_at, direction,
+                    from_email, to_addrs, cc_addrs, bcc_addrs,
+                    subject, text, html, headers
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """
+            params = (
+                email.id,
+                email.conversation_id,
+                int(email.created_at.timestamp()),
+                email.direction.value,
+                email.from_email,
+                json.dumps(email.to),
+                json.dumps(email.cc),
+                json.dumps(email.bcc),
+                email.subject,
+                email.text,
+                email.html,
+                json.dumps(email.headers),
+            )
+            logger.info("SQL: %s | Params: %s", sql.strip(), params)
+            cursor.execute(sql, params)
+            assert cursor.rowcount == 1, (
+                f"Failed to insert email {email.id}: {cursor.rowcount} rows"
+            )
+            conn.commit()
+
+    @staticmethod
+    def get_by_conversation(conversation_id: str) -> list[EmailMessage]:
+        """Retrieve all emails for a conversation."""
+        logger.debug("Loading emails for conversation %s", conversation_id)
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            sql = "SELECT * FROM emails WHERE conversation_id = ? ORDER BY created_at"
+            params = (conversation_id,)
+            logger.info("SQL: %s | Params: %s", sql, params)
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+        return [
+            EmailMessage(
+                id=row[0],
+                conversation_id=row[1],
+                created_at=datetime.fromtimestamp(row[2], UTC),
+                direction=EmailDirection(row[3]),
+                from_email=row[4],
+                to=json.loads(row[5]),
+                cc=json.loads(row[6]),
+                bcc=json.loads(row[7]),
+                subject=row[8],
+                text=row[9],
+                html=row[10],
+                headers=json.loads(row[11]) if row[11] else {},
+            )
+            for row in rows
+        ]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    from quinn.models.email import EmailMessage
+
+    sample = EmailMessage(
+        id="<demo>",
+        conversation_id="demo-conv",
+        from_email="alice@example.com",
+        to=["bob@example.com"],
+        subject="Hello",
+        text="Just a demo",
+    )
+    EmailStore.create(sample)
+    print(EmailStore.get_by_conversation("demo-conv"))

--- a/quinn/db/emails_test.py
+++ b/quinn/db/emails_test.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from quinn.db.conversations import Conversations, ConversationStore
+from quinn.db.emails import EmailStore
+from quinn.db.users import Users
+from quinn.models.email import EmailDirection, EmailMessage
+from quinn.models.user import User
+
+
+def test_emails_create_and_get(clean_db: Path) -> None:
+    user = User(id="u1", email_addresses=["a@example.com"])
+    Users.create(user)
+    conv = ConversationStore(conversation_id="conv1", user_id="u1")
+    Conversations.create(conv)
+    email = EmailMessage(
+        id="<e1>",
+        conversation_id="conv1",
+        direction=EmailDirection.INBOUND,
+        from_email="a@example.com",
+        to=["b@example.com"],
+        subject="hi",
+        text="hello",
+    )
+    EmailStore.create(email)
+    result = EmailStore.get_by_conversation("conv1")
+    assert clean_db  # trigger fixture
+    assert len(result) == 1
+    assert result[0].id == "<e1>"

--- a/quinn/db/schema.sql
+++ b/quinn/db/schema.sql
@@ -36,3 +36,22 @@
       FOREIGN KEY (conversation_id) REFERENCES conversations (id),
       FOREIGN KEY (user_id) REFERENCES users (id)
   );
+
+  -- Emails table
+  CREATE TABLE emails (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      direction TEXT NOT NULL,
+      from_email TEXT NOT NULL,
+      to_addrs TEXT NOT NULL,
+      cc_addrs TEXT NOT NULL,
+      bcc_addrs TEXT NOT NULL,
+      subject TEXT,
+      text TEXT,
+      html TEXT,
+      headers TEXT,
+      FOREIGN KEY (conversation_id) REFERENCES conversations (id)
+  );
+  CREATE INDEX idx_emails_conversation_created_at
+      ON emails (conversation_id, created_at);

--- a/quinn/email/__init__.py
+++ b/quinn/email/__init__.py
@@ -1,0 +1,17 @@
+"""Email utilities for Quinn."""
+
+from quinn.models.email import EmailAttachment, EmailMessage
+
+from .inbound import build_thread_context, parse_postmark_webhook
+from .outbound import format_reply, send_email
+from .security import verify_postmark_signature
+
+__all__ = [
+    "EmailAttachment",
+    "EmailMessage",
+    "build_thread_context",
+    "format_reply",
+    "parse_postmark_webhook",
+    "send_email",
+    "verify_postmark_signature",
+]

--- a/quinn/email/inbound.py
+++ b/quinn/email/inbound.py
@@ -1,0 +1,92 @@
+"""Utilities for handling inbound Postmark webhooks."""
+
+import json
+import sys
+from email.utils import parseaddr
+from typing import Any
+
+from quinn.db.emails import EmailStore
+from quinn.models.email import EmailAttachment, EmailDirection, EmailMessage
+from quinn.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _parse_attachments(data: list[dict[str, Any]]) -> list[EmailAttachment]:
+    return [
+        EmailAttachment(
+            name=att.get("Name", ""),
+            content_type=att.get("ContentType", ""),
+            content=att.get("Content", ""),
+            content_length=int(att.get("ContentLength", 0)),
+        )
+        for att in data or []
+    ]
+
+
+def parse_postmark_webhook(
+    payload: dict[str, Any], allowed_senders: list[str] | None = None
+) -> EmailMessage:
+    """Parse Postmark inbound webhook JSON to an :class:`EmailMessage`."""
+    message_id = payload.get("MessageID", "")
+    subject = payload.get("Subject", "")
+    text_body = payload.get("TextBody", "")
+    html_body = payload.get("HtmlBody", "")
+    from_field = payload.get("From", "")
+
+    if allowed_senders is not None:
+        _, addr = parseaddr(from_field)
+        if addr.lower() not in {a.lower() for a in allowed_senders}:
+            msg = "Sender not allowed"
+            raise ValueError(msg)
+
+    to_field = payload.get("To", "")
+    cc_field = payload.get("Cc", "")
+    bcc_field = payload.get("Bcc", "")
+
+    headers = {h["Name"]: h["Value"] for h in payload.get("Headers", [])}
+    in_reply_to = headers.get("In-Reply-To")
+    references_header = headers.get("References", "")
+    references = [r for r in references_header.split() if r]
+
+    attachments = _parse_attachments(payload.get("Attachments", []))
+
+    email = EmailMessage(
+        id=message_id,
+        subject=subject,
+        from_email=from_field,
+        to=[addr.strip() for addr in to_field.split(";") if addr.strip()],
+        cc=[addr.strip() for addr in cc_field.split(";") if addr.strip()],
+        bcc=[addr.strip() for addr in bcc_field.split(";") if addr.strip()],
+        text=text_body,
+        html=html_body,
+        headers=headers,
+        attachments=attachments,
+        mailbox_hash=payload.get("MailboxHash"),
+        in_reply_to=in_reply_to,
+        references=references,
+        direction=EmailDirection.INBOUND,
+        conversation_id=payload.get("MailboxHash", ""),
+    )
+    logger.info("Parsed inbound email %s hash=%s", email.id, email.mailbox_hash)
+    EmailStore.create(email)
+    return email
+
+
+def build_thread_context(new_email: EmailMessage, history: list[EmailMessage]) -> str:
+    """Build conversation text from previous emails and the new one."""
+    parts = [f"{msg.sender_address}: {msg.text}" for msg in history]
+    parts.append(f"{new_email.sender_address}: {new_email.text}")
+    return "\n\n".join(parts)
+
+
+def main() -> None:
+    """CLI entry for parsing inbound payload from stdin."""
+    raw = sys.stdin.read()
+    payload = json.loads(raw)
+    email = parse_postmark_webhook(payload)
+    print(email.model_dump())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    main()

--- a/quinn/email/inbound_test.py
+++ b/quinn/email/inbound_test.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from quinn.email.inbound import build_thread_context, parse_postmark_webhook
+from quinn.models.email import EmailMessage
+
+
+def test_parse_postmark_webhook_basic() -> None:
+    payload = {
+        "MessageID": "<msg1@pm>",
+        "From": "Alice <alice@example.com>",
+        "To": "quinn@example.com",
+        "Subject": "Test",
+        "TextBody": "Hello\n> quote",
+        "Headers": [
+            {"Name": "In-Reply-To", "Value": "<old@pm>"},
+            {"Name": "References", "Value": "<ref1> <ref2>"},
+        ],
+        "Attachments": [
+            {
+                "Name": "a.txt",
+                "ContentType": "text/plain",
+                "Content": "dGVzdA==",
+                "ContentLength": 4,
+            }
+        ],
+    }
+    with patch("quinn.email.inbound.EmailStore.create"):
+        email = parse_postmark_webhook(payload, ["alice@example.com"])
+    assert email.id == "<msg1@pm>"
+    assert email.in_reply_to == "<old@pm>"
+    assert email.references == ["<ref1>", "<ref2>"]
+    assert email.attachments[0].name == "a.txt"
+
+
+def test_build_thread_context() -> None:
+    history = [
+        EmailMessage(from_email="a@example.com", text="Hi"),
+        EmailMessage(from_email="b@example.com", text="Reply"),
+    ]
+    new = EmailMessage(from_email="c@example.com", text="Final")
+    ctx = build_thread_context(new, history)
+    assert "a@example.com: Hi" in ctx
+    assert "c@example.com: Final" in ctx

--- a/quinn/email/outbound.py
+++ b/quinn/email/outbound.py
@@ -1,0 +1,102 @@
+"""Functions for sending emails via Postmark."""
+
+import asyncio
+import os
+from typing import Any
+from uuid import uuid4
+
+import httpx
+
+from quinn.db.emails import EmailStore
+from quinn.models.email import EmailDirection, EmailMessage
+from quinn.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+POSTMARK_ENDPOINT = "https://api.postmarkapp.com/email"
+
+
+async def send_email(
+    email: EmailMessage,
+    server_token: str,
+    retries: int = 3,
+) -> httpx.Response:
+    """Send an email using the Postmark API."""
+    payload: dict[str, Any] = {
+        "From": email.from_email,
+        "To": ",".join(email.to),
+        "Cc": ",".join(email.cc),
+        "Bcc": ",".join(email.bcc),
+        "Subject": email.subject,
+        "TextBody": email.text,
+        "HtmlBody": email.html,
+        "Headers": [{"Name": k, "Value": v} for k, v in email.headers.items()],
+    }
+    attempt = 0
+    while True:
+        try:
+            logger.info("Sending email %s", email.id)
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    POSTMARK_ENDPOINT,
+                    headers={
+                        "Accept": "application/json",
+                        "X-Postmark-Server-Token": server_token,
+                    },
+                    json=payload,
+                )
+            resp.raise_for_status()
+            EmailStore.create(email)
+            return resp
+        except Exception:  # pragma: no cover - network failure scenario
+            attempt += 1
+            if attempt > retries:
+                raise
+            await asyncio.sleep(min(2**attempt, 10))
+
+
+def format_reply(
+    original: EmailMessage,
+    reply_text: str,
+    from_addr: str,
+    html_body: str | None = None,
+) -> EmailMessage:
+    """Create a reply email referencing the original thread."""
+    new_headers = dict(original.headers)
+    new_headers["In-Reply-To"] = original.id
+    refs = [*original.references, original.id]
+    new_headers["References"] = " ".join(refs)
+    return EmailMessage(
+        id=f"<{uuid4()}@quinn.email>",
+        subject=f"Re: {original.subject}",
+        from_email=from_addr,
+        to=[original.sender_address],
+        cc=original.cc,
+        bcc=original.bcc,
+        text=reply_text,
+        html=html_body or "",
+        headers=new_headers,
+        in_reply_to=original.id,
+        references=refs,
+        conversation_id=original.conversation_id,
+        direction=EmailDirection.OUTBOUND,
+    )
+
+
+def main() -> None:
+    """Simple demonstration for sending an email."""
+    token = os.environ.get("POSTMARK_TOKEN", "POSTMARK_API_TEST")
+    email = EmailMessage(
+        id=str(uuid4()),
+        conversation_id="demo",
+        from_email="support@quinn.email",
+        to=["user@example.com"],
+        subject="Demo",
+        text="Hello from Quinn",
+        direction=EmailDirection.OUTBOUND,
+    )
+    asyncio.run(send_email(email, token))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    main()

--- a/quinn/email/outbound_test.py
+++ b/quinn/email/outbound_test.py
@@ -1,0 +1,40 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from quinn.email.outbound import format_reply, send_email
+from quinn.models.email import EmailDirection, EmailMessage
+
+
+async def _run_send() -> None:
+    email = EmailMessage(
+        id="<id1@pm>",
+        from_email="q@example.com",
+        to=["a@example.com"],
+        subject="hi",
+        direction=EmailDirection.OUTBOUND,
+        conversation_id="conv1",
+    )
+    with (
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post,
+        patch("quinn.email.outbound.EmailStore.create"),
+    ):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status = lambda: None
+        await send_email(email, "token")
+        assert mock_post.call_args is not None
+
+
+def test_send_email() -> None:
+    asyncio.run(_run_send())
+
+
+def test_format_reply() -> None:
+    original = EmailMessage(
+        id="<id@pm>",
+        subject="Hello",
+        from_email="bob@example.com",
+        conversation_id="conv1",
+    )
+    reply = format_reply(original, "hi", "quinn@example.com")
+    assert reply.in_reply_to == "<id@pm>"
+    assert "References" in reply.headers

--- a/quinn/email/security.py
+++ b/quinn/email/security.py
@@ -1,0 +1,29 @@
+"""Security utilities for Postmark webhooks."""
+
+import base64
+import hashlib
+import hmac
+
+from quinn.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def verify_postmark_signature(token: str, body: bytes, signature: str) -> bool:
+    """Return ``True`` if signature matches ``body`` using the given token."""
+    digest = hmac.new(token.encode(), body, hashlib.sha256).digest()
+    expected = base64.b64encode(digest).decode()
+    return hmac.compare_digest(expected, signature)
+
+
+def main() -> None:
+    """Demonstrate signature verification."""
+    token = "demo"
+    body = b"{}"
+    digest = hmac.new(token.encode(), body, hashlib.sha256).digest()
+    signature = base64.b64encode(digest).decode()
+    print(verify_postmark_signature(token, body, signature))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    main()

--- a/quinn/email/security_test.py
+++ b/quinn/email/security_test.py
@@ -1,0 +1,13 @@
+import base64
+import hashlib
+import hmac
+
+from quinn.email.security import verify_postmark_signature
+
+
+def test_verify_postmark_signature() -> None:
+    token = "token"
+    body = b"{}"
+    digest = hmac.new(token.encode(), body, hashlib.sha256).digest()
+    signature = base64.b64encode(digest).decode()
+    assert verify_postmark_signature(token, body, signature)

--- a/quinn/models/__init__.py
+++ b/quinn/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import AgentConfig
 from .conversation import Conversation, ConversationMetrics, Message
+from .email import EmailAttachment, EmailDirection, EmailMessage
 from .message import MessageMetrics
 from .types import PROMPT_VERSION
 
@@ -13,6 +14,9 @@ __all__ = [
     "AgentConfig",
     "Conversation",
     "ConversationMetrics",
+    "EmailAttachment",
+    "EmailDirection",
+    "EmailMessage",
     "Message",
     "MessageMetrics",
 ]

--- a/quinn/models/email.py
+++ b/quinn/models/email.py
@@ -1,0 +1,63 @@
+"""Email data models."""
+
+from datetime import UTC, datetime
+from email.utils import parseaddr
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class EmailDirection(str, Enum):
+    """Inbound or outbound email."""
+
+    INBOUND = "inbound"
+    OUTBOUND = "outbound"
+
+
+class EmailAttachment(BaseModel):
+    """Representation of an email attachment."""
+
+    name: str = ""
+    content_type: str = ""
+    content: str = ""
+    content_length: int = 0
+
+
+class EmailMessage(BaseModel):
+    """Simplified email message model."""
+
+    id: str = ""
+    conversation_id: str = ""
+    direction: EmailDirection = EmailDirection.INBOUND
+    subject: str = ""
+    from_email: str = ""
+    to: list[str] = Field(default_factory=list)
+    cc: list[str] = Field(default_factory=list)
+    bcc: list[str] = Field(default_factory=list)
+    text: str = ""
+    html: str = ""
+    headers: dict[str, str] = Field(default_factory=dict)
+    attachments: list[EmailAttachment] = Field(default_factory=list)
+    mailbox_hash: str | None = None
+    in_reply_to: str | None = None
+    references: list[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def sender_address(self) -> str:
+        """Return the plain email address of the sender."""
+        _, addr = parseaddr(self.from_email)
+        return addr
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "pytest" not in sys.modules:
+        sample = EmailMessage(
+            id="<demo@quinn.email>",
+            subject="Demo",
+            from_email="Alice <alice@example.com>",
+            to=["quinn@example.com"],
+        )
+        print(sample)

--- a/quinn/utils/logging.py
+++ b/quinn/utils/logging.py
@@ -24,6 +24,14 @@ class ContextFilter(logging.Filter):
         return True
 
 
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with context filtering enabled."""
+    logger = logging.getLogger(name)
+    if not any(isinstance(f, ContextFilter) for f in logger.filters):
+        logger.addFilter(ContextFilter())
+    return logger
+
+
 def set_trace_id(mailbox_hash: str, message_id: str) -> str:
     """Set the trace ID using the mailbox hash and message ID."""
     trace_id = f"{mailbox_hash}:{message_id}"


### PR DESCRIPTION
## Summary
- rename `Emails` to `EmailStore` and add rowcount assertion
- store conversation data using new `ConversationStore` model
- remove unused RateLimiter and quoted-text helper
- index `emails` table by conversation and timestamp

## Testing
- `uv run ruff check quinn/cli.py quinn/db/conversations.py quinn/db/emails.py quinn/email/__init__.py quinn/email/inbound.py quinn/email/outbound.py quinn/email/security.py`
- `uv run ty check quinn/cli.py quinn/db/conversations.py quinn/db/emails.py quinn/email/__init__.py quinn/email/inbound.py quinn/email/outbound.py quinn/email/security.py`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882bd014a1c8324a704899f0930c54c