### PR TITLE
Expose postmark webhook

### DIFF
--- a/quinn/email/__init__.py
+++ b/quinn/email/__init__.py
@@ -5,6 +5,7 @@ from quinn.models.email import EmailAttachment, EmailMessage
 from .inbound import build_thread_context, parse_postmark_webhook
 from .outbound import format_reply, send_email
 from .security import verify_postmark_signature
+from .web import app as postmark_web_app
 
 __all__ = [
     "EmailAttachment",
@@ -12,6 +13,7 @@ __all__ = [
     "build_thread_context",
     "format_reply",
     "parse_postmark_webhook",
+    "postmark_web_app",
     "send_email",
     "verify_postmark_signature",
 ]

--- a/quinn/email/web.py
+++ b/quinn/email/web.py
@@ -1,0 +1,38 @@
+import json
+import os
+
+from fasthtml.core import JSONResponse, serve
+from fasthtml.fastapp import fast_app
+from fasthtml.starlette import Request
+
+from quinn.email.inbound import parse_postmark_webhook
+from quinn.email.security import verify_postmark_signature
+from quinn.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+app, _ = fast_app()
+
+
+@app.post("/webhook/postmark")
+async def postmark(req: Request) -> JSONResponse:
+    """Handle inbound Postmark webhook."""
+    body = await req.body()
+    token = os.getenv("POSTMARK_INBOUND_TOKEN", "")
+    if token:
+        signature = req.headers.get("x-postmark-signature", "")
+        assert verify_postmark_signature(token, body, signature), "invalid signature"
+    allowed = os.getenv("QUINN_ALLOWED_SENDERS")
+    senders = [s.strip() for s in allowed.split(",") if s.strip()] if allowed else None
+    payload = json.loads(body)
+    email = parse_postmark_webhook(payload, senders)
+    logger.info("Inbound email processed %s", email.id)
+    return JSONResponse({"status": "ok"})
+
+
+def main() -> None:
+    serve()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    main()

--- a/quinn/email/web_test.py
+++ b/quinn/email/web_test.py
@@ -1,0 +1,34 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+from unittest.mock import patch
+
+from fasthtml.core import Client
+from typing import Any, cast
+
+from quinn.email.web import app
+
+
+def _signature(token: str, body: bytes) -> str:
+    digest = hmac.new(token.encode(), body, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode()
+
+
+def test_postmark_webhook_route() -> None:
+    payload = {"MessageID": "<id@pm>", "From": "Alice <alice@example.com>"}
+    body = json.dumps(payload).encode()
+    token = "secret"
+    os.environ["POSTMARK_INBOUND_TOKEN"] = token
+    sig = _signature(token, body)
+    with patch("quinn.email.web.parse_postmark_webhook") as parse:
+        client = Client(app)
+        resp = cast(Any, client).post(
+            "/webhook/postmark",
+            data=body,
+            headers={"x-postmark-signature": sig},
+        )
+        assert resp.status_code == 200
+        parse.assert_called_once_with(payload, None)
+    del os.environ["POSTMARK_INBOUND_TOKEN"]


### PR DESCRIPTION
## Summary
- implement an inbound webhook app for Postmark
- export the web app via `quinn.email`
- test the new endpoint

## Testing
- `make dev`
- `make test`
- `make test-coverage`
- `make type-coverage`


------
https://chatgpt.com/codex/tasks/task_e_6882c84dfcdc8324a6a52e6a59f85b79