### PR TITLE
Fix httpx deprecation warning in tests

### DIFF
--- a/quinn/email/web_test.py
+++ b/quinn/email/web_test.py
@@ -3,10 +3,11 @@ import hashlib
 import hmac
 import json
 import os
+from http import HTTPStatus
+from typing import Any, cast
 from unittest.mock import patch
 
 from fasthtml.core import Client
-from typing import Any, cast
 
 from quinn.email.web import app
 
@@ -24,11 +25,11 @@ def test_postmark_webhook_route() -> None:
     sig = _signature(token, body)
     with patch("quinn.email.web.parse_postmark_webhook") as parse:
         client = Client(app)
-        resp = cast(Any, client).post(
+        resp = cast("Any", client).post(
             "/webhook/postmark",
-            data=body,
+            content=body,
             headers={"x-postmark-signature": sig},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == HTTPStatus.OK
         parse.assert_called_once_with(payload, None)
     del os.environ["POSTMARK_INBOUND_TOKEN"]


### PR DESCRIPTION
## Summary
- fix Postmark webhook test to use `content` instead of `data`
- address ruff lint warnings in the test

## Testing
- `uv run ruff check quinn/email/web_test.py`
- `uv run ty check quinn/email/web_test.py`
- `uv run pytest -vv quinn/email/web_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6882eed15618832492ed3fd6362e1960