### PR TITLE
Ensure 100% coverage for email security utils

### DIFF
--- a/quinn/email/security.py
+++ b/quinn/email/security.py
@@ -8,6 +8,8 @@ from quinn.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = ["main", "verify_postmark_signature"]
+
 
 def verify_postmark_signature(token: str, body: bytes, signature: str) -> bool:
     """Return ``True`` if signature matches ``body`` using the given token."""

--- a/quinn/email/security_test.py
+++ b/quinn/email/security_test.py
@@ -2,7 +2,9 @@ import base64
 import hashlib
 import hmac
 
-from quinn.email.security import verify_postmark_signature
+import pytest
+
+from quinn.email.security import main, verify_postmark_signature
 
 
 def test_verify_postmark_signature() -> None:
@@ -11,3 +13,10 @@ def test_verify_postmark_signature() -> None:
     digest = hmac.new(token.encode(), body, hashlib.sha256).digest()
     signature = base64.b64encode(digest).decode()
     assert verify_postmark_signature(token, body, signature)
+
+
+def test_main_prints_true(capsys: pytest.CaptureFixture[str]) -> None:
+    """Ensure the demo main function prints True."""
+    main()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "True"


### PR DESCRIPTION
## Summary
- export functions in `security` module
- add tests for demo `main` function

## Testing
- `uv run pytest quinn/email/security_test.py --cov=quinn.email.security --cov-report=term-missing -vv`

------
https://chatgpt.com/codex/tasks/task_e_6882f01a9c7083249a50efc3394350b4