### PR TITLE
Improve config coverage

### DIFF
--- a/quinn/models/config.py
+++ b/quinn/models/config.py
@@ -199,7 +199,8 @@ class AgentConfig(BaseModel):
             # Check if it's a classmethod that returns AgentConfig
             if hasattr(method, "__self__") and method.__self__ is cls:
                 sig = inspect.signature(method)
-                if len(sig.parameters) > 0:  # Only cls parameter
+                # Skip methods that expect additional arguments
+                if len(sig.parameters) > 0:
                     continue
 
                 config_instance = method()


### PR DESCRIPTION
## Summary
- ensure `get_all_models` handles atypical methods
- run module as script to cover `__main__` guard
- tweak comment in `get_all_models`
- tests now achieve full coverage

## Testing
- `.venv/bin/coverage run --source=quinn/models -m pytest quinn/models/config_test.py -q`
- `.venv/bin/coverage report quinn/models/config.py`


------
https://chatgpt.com/codex/tasks/task_e_6882f04035dc8324ac0777d69d0732c8