### PR TITLE
Improve logging module coverage

### DIFF
--- a/quinn/utils/logging_test.py
+++ b/quinn/utils/logging_test.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 from importlib import reload
 from pathlib import Path
 
@@ -35,3 +36,38 @@ def test_setup_logging_debug_modules(tmp_path: Path) -> None:
     assert logger.level == logging.DEBUG
     assert log_file.exists()
     reload(logging_utils)  # reset for other tests
+
+
+def test_setup_logging_no_debug_modules(tmp_path: Path) -> None:
+    """Coverage for branch when no debug modules provided."""
+    log_file = tmp_path / "nodebug.log"
+    logging_utils.setup_logging(level=logging.INFO, log_file=str(log_file))
+    logging.getLogger("nodebug").info("hi")
+    assert log_file.exists()
+    reload(logging_utils)
+
+
+def test_get_logger_filter_added() -> None:
+    """Ensure context filter is added exactly once."""
+    logger = logging_utils.get_logger("foo")
+    assert any(isinstance(f, logging_utils.ContextFilter) for f in logger.filters)
+    logger_again = logging_utils.get_logger("foo")
+    assert logger is logger_again
+    count = sum(isinstance(f, logging_utils.ContextFilter) for f in logger.filters)
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_trace_async() -> None:
+    """Async function should get a fresh span id on each call."""
+
+    @logging_utils.trace
+    async def sample() -> str:
+        return logging_utils.span_id_var.get()
+
+    first = await sample()
+    second = await sample()
+    assert len(first) == 16
+    assert len(second) == 16
+    assert first != second
+    assert logging_utils.span_id_var.get() == second


### PR DESCRIPTION
## Summary
- test setup_logging branch with no debug modules
- ensure get_logger only adds one ContextFilter
- exercise trace decorator with async functions

## Testing
- `ruff format quinn/utils/logging_test.py quinn/utils/logging.py`
- `ruff check quinn/utils/logging.py quinn/utils/logging_test.py`
- `ty check quinn/utils/logging.py quinn/utils/logging_test.py`
- `pytest quinn/utils/logging_test.py -q`
- `pytest quinn/utils/logging_test.py --cov=quinn.utils.logging --cov-report=term-missing -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f02b95f483248cec49f6abca6670