### PR TITLE
Improve coverage for email webhook

### DIFF
--- a/quinn/email/web.py
+++ b/quinn/email/web.py
@@ -14,6 +14,14 @@ logger = get_logger(__name__)
 app, _ = fast_app()
 
 
+def _get_allowed_senders() -> list[str] | None:
+    """Return allowed senders list from the environment."""
+    allowed = os.getenv("QUINN_ALLOWED_SENDERS", "")
+    parts = [s.strip() for s in allowed.split(",")]
+    filtered = [p for p in parts if p]
+    return filtered or None
+
+
 @app.post("/webhook/postmark")
 async def postmark(req: Request) -> JSONResponse:
     """Handle inbound Postmark webhook."""
@@ -22,8 +30,7 @@ async def postmark(req: Request) -> JSONResponse:
     if token:
         signature = req.headers.get("x-postmark-signature", "")
         assert verify_postmark_signature(token, body, signature), "invalid signature"
-    allowed = os.getenv("QUINN_ALLOWED_SENDERS")
-    senders = [s.strip() for s in allowed.split(",") if s.strip()] if allowed else None
+    senders = _get_allowed_senders()
     payload = json.loads(body)
     email = parse_postmark_webhook(payload, senders)
     logger.info("Inbound email processed %s", email.id)
@@ -36,3 +43,6 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation only
     main()
+
+
+__all__ = ["app", "main", "postmark"]

--- a/quinn/email/web_test.py
+++ b/quinn/email/web_test.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
 import base64
 import hashlib
 import hmac
 import json
 import os
+from http import HTTPStatus
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from fasthtml.core import Client
-from typing import Any, cast
 
+if TYPE_CHECKING:
+    import pytest
+
+from quinn.email import web
 from quinn.email.web import app
 
 
@@ -24,11 +31,36 @@ def test_postmark_webhook_route() -> None:
     sig = _signature(token, body)
     with patch("quinn.email.web.parse_postmark_webhook") as parse:
         client = Client(app)
-        resp = cast(Any, client).post(
+        resp = client.post(  # type: ignore[attr-defined]
             "/webhook/postmark",
             data=body,
             headers={"x-postmark-signature": sig},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == HTTPStatus.OK
         parse.assert_called_once_with(payload, None)
     del os.environ["POSTMARK_INBOUND_TOKEN"]
+
+
+def test_postmark_webhook_allowed_senders(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"MessageID": "<id@pm>", "From": "Alice <alice@example.com>"}
+    body = json.dumps(payload).encode()
+    monkeypatch.delenv("POSTMARK_INBOUND_TOKEN", raising=False)
+    monkeypatch.setenv(
+        "QUINN_ALLOWED_SENDERS",
+        "alice@example.com, bob@example.com",
+    )
+    with (
+        patch("quinn.email.web.parse_postmark_webhook") as parse,
+        patch("quinn.email.web.verify_postmark_signature") as verify,
+    ):
+        client = Client(app)
+        resp = client.post("/webhook/postmark", data=body)  # type: ignore[attr-defined]
+        assert resp.status_code == HTTPStatus.OK
+        parse.assert_called_once_with(payload, ["alice@example.com", "bob@example.com"])
+        verify.assert_not_called()
+
+
+def test_main_calls_serve() -> None:
+    with patch("quinn.email.web.serve") as mocked:
+        web.main()
+        mocked.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add helper to fetch allowed senders in email webhook
- export functions via `__all__`
- test alternate branches in webhook handler
- ensure `main` calls `serve`

## Testing
- `uv run ty check quinn/email/web.py quinn/email/web_test.py`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f01ee18083249133e64e559275f1