### PR TITLE
Improve demo cost savings and achieve full coverage

### DIFF
--- a/quinn/agent/cost.py
+++ b/quinn/agent/cost.py
@@ -203,8 +203,10 @@ def _demo_model_costs(
     else:
         print("   Cached input cost per token: Not supported")
 
-    # Calculate total cost without caching
-    total_cost = calculate_cost(model, input_tokens, output_tokens)
+    # Calculate total cost without caching. This assumes the cached tokens would
+    # otherwise be billed as regular input tokens. Using the combined total
+    # provides a meaningful comparison for the cache savings printout below.
+    total_cost = calculate_cost(model, input_tokens + cached_tokens, output_tokens)
     print(f"   Total cost (no cache): ${total_cost:.6f}")
 
     # Calculate total cost with caching


### PR DESCRIPTION
## Summary
- fix `_demo_model_costs` to correctly compute cache savings
- verify cache savings output in tests
- consolidate imports and clean up style

## Testing
- `uv run ruff check quinn/agent/cost.py quinn/agent/cost_test.py`
- `uv run ty check quinn/agent/cost.py quinn/agent/cost_test.py`
- `uv run pytest -vv quinn/agent/cost_test.py --cov=quinn.agent.cost --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6882efd71cb083248134b25827dab34c