### PR TITLE
Improve prompt versioning test coverage

### DIFF
--- a/quinn/agent/versioning.py
+++ b/quinn/agent/versioning.py
@@ -12,12 +12,27 @@ def get_current_prompt_version() -> PROMPT_VERSION:
     return f"v{now.strftime('%y%m%d-%H%M%S')}"
 
 
-def load_system_prompt(version: str | PROMPT_VERSION = "latest") -> str:
-    """Load system prompt by version."""
+def load_system_prompt(
+    version: str | PROMPT_VERSION = "latest",
+    project_root: Path | None = None,
+) -> str:
+    """Load system prompt by version.
+
+    Parameters
+    ----------
+    version:
+        The prompt version identifier. ``"latest"`` loads the default prompt.
+    project_root:
+        Optional base directory for locating the prompt files. When ``None`` the
+        path is derived from ``__file__`` which points to the installed
+        location of the package. This parameter exists primarily for testing and
+        does not change the public behaviour of the function.
+    """
     assert version.strip(), "Version cannot be empty"
 
     # Look for prompt files in templates directory
-    project_root = Path(__file__).parent.parent.parent
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.parent
     prompts_dir = project_root / "quinn" / "templates" / "prompts"
 
     if version == "latest":
@@ -43,12 +58,22 @@ Key principles:
     return prompt_file.read_text().strip()
 
 
-def save_prompt_version(version: PROMPT_VERSION, content: str) -> None:
-    """Save a new prompt version."""
+def save_prompt_version(
+    version: PROMPT_VERSION,
+    content: str,
+    project_root: Path | None = None,
+) -> None:
+    """Save a new prompt version.
+
+    This helper writes ``content`` to a versioned prompt file. ``project_root``
+    mirrors the argument of :func:`load_system_prompt` and allows tests to
+    operate without touching the real filesystem.
+    """
     assert version.strip(), "Version cannot be empty"
     assert content.strip(), "Prompt content cannot be empty"
 
-    project_root = Path(__file__).parent.parent.parent
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.parent
     prompts_dir = project_root / "quinn" / "templates" / "prompts"
     prompts_dir.mkdir(parents=True, exist_ok=True)
 

--- a/quinn/agent/versioning_test.py
+++ b/quinn/agent/versioning_test.py
@@ -2,34 +2,41 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from .versioning import get_current_prompt_version, load_system_prompt, save_prompt_version
+from .versioning import (
+    get_current_prompt_version,
+    load_system_prompt,
+    save_prompt_version,
+)
+
+MIN_LEN = 2
 
 
 def test_get_current_prompt_version() -> None:
     """Test current prompt version generation."""
     version1 = get_current_prompt_version()
     version2 = get_current_prompt_version()
-    
+
     # Should be strings starting with 'v'
     assert isinstance(version1, str)
     assert version1.startswith("v")
-    assert isinstance(version2, str) 
+    assert isinstance(version2, str)
     assert version2.startswith("v")
-    
+
     # Should be timestamp-based, so likely different (unless called in same second)
     # We'll just check they're valid format
-    assert len(version1) > 2  # At least 'v' + some digits
-    assert len(version2) > 2
+    assert len(version1) > MIN_LEN  # At least 'v' + some digits
+    assert len(version2) > MIN_LEN
 
 
 def test_load_system_prompt_fallback() -> None:
     """Test loading system prompt with fallback when file doesn't exist."""
     # Load from non-existent path - should return fallback
     prompt = load_system_prompt("nonexistent_version")
-    
+
     assert isinstance(prompt, str)
     assert len(prompt) > 0
     assert "You are Quinn" in prompt
@@ -40,7 +47,7 @@ def test_load_system_prompt_fallback() -> None:
 def test_load_system_prompt_latest() -> None:
     """Test loading latest system prompt."""
     prompt = load_system_prompt("latest")
-    
+
     assert isinstance(prompt, str)
     assert len(prompt) > 0
     # Should get fallback since file doesn't exist
@@ -51,46 +58,41 @@ def test_save_and_load_prompt_version() -> None:
     """Test saving and loading a specific prompt version."""
     test_content = "Test system prompt for version testing."
     test_version = "test_v123"
-    
+
     # Create a temporary directory for testing
     with tempfile.TemporaryDirectory() as temp_dir:
         # Monkey patch the project root to use temp directory
-        original_parent = Path(__file__).parent.parent.parent
         temp_project_root = Path(temp_dir)
-        
-        # Override the project root path in versioning module
-        import quinn.agent.versioning as versioning_module
-        original_file = versioning_module.__file__
-        
+
         # Mock the path calculation
         def mock_save_prompt_version(version: str, content: str) -> None:
             assert version.strip(), "Version cannot be empty"
             assert content.strip(), "Prompt content cannot be empty"
-            
+
             prompts_dir = temp_project_root / "quinn" / "templates" / "prompts"
             prompts_dir.mkdir(parents=True, exist_ok=True)
-            
+
             prompt_file = prompts_dir / f"system_{version}.txt"
             prompt_file.write_text(content)
-        
+
         def mock_load_system_prompt(version: str = "latest") -> str:
             assert version.strip(), "Version cannot be empty"
-            
+
             prompts_dir = temp_project_root / "quinn" / "templates" / "prompts"
-            
+
             if version == "latest":
                 prompt_file = prompts_dir / "system.txt"
             else:
                 prompt_file = prompts_dir / f"system_{version}.txt"
-            
+
             if not prompt_file.exists():
                 return "Fallback prompt for testing"
-            
+
             return prompt_file.read_text().strip()
-        
+
         # Test save
         mock_save_prompt_version(test_version, test_content)
-        
+
         # Test load
         loaded_content = mock_load_system_prompt(test_version)
         assert loaded_content == test_content
@@ -98,41 +100,37 @@ def test_save_and_load_prompt_version() -> None:
 
 def test_save_prompt_version_validation() -> None:
     """Test prompt version saving validation."""
-    
+
     with pytest.raises(AssertionError, match="Version cannot be empty"):
         save_prompt_version("", "v1.0")
-    
+
     with pytest.raises(AssertionError, match="Version cannot be empty"):
         save_prompt_version("   ", "v1.0")  # Whitespace only
-    
+
     with pytest.raises(AssertionError, match="Prompt content cannot be empty"):
         save_prompt_version("v1.0", "")
-    
+
     with pytest.raises(AssertionError, match="Prompt content cannot be empty"):
         save_prompt_version("v1.0", "   ")  # Whitespace only
 
 
 def test_load_system_prompt_validation() -> None:
     """Test system prompt loading validation."""
-    
+
     with pytest.raises(AssertionError, match="Version cannot be empty"):
         load_system_prompt("")
-    
+
     with pytest.raises(AssertionError, match="Version cannot be empty"):
         load_system_prompt("   ")  # Whitespace only
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
-
 def test_load_system_prompt_fallback_content() -> None:
     """Test that fallback prompt contains expected content."""
-    from unittest.mock import patch
-    
+
     # Mock file not found to trigger fallback
     with patch("pathlib.Path.exists", return_value=False):
         prompt = load_system_prompt()
-        
+
         # Check that fallback content is returned
         assert "You are Quinn" in prompt
         assert "encouraging and supportive" in prompt
@@ -141,75 +139,76 @@ def test_load_system_prompt_fallback_content() -> None:
 
 def test_save_prompt_version() -> None:
     """Test saving a prompt version."""
-    import tempfile
-    from pathlib import Path
-    from unittest.mock import patch, MagicMock
-    
     test_content = "Test system prompt content"
     test_version = "240715-120000"
-    
+
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        
-        # Mock the Path(__file__).parent.parent.parent chain
-        mock_file_path = MagicMock()
-        mock_file_path.parent.parent.parent = temp_path
-        
-        with patch("quinn.agent.versioning.Path") as mock_path:
-            mock_path.return_value = mock_file_path
-            mock_path.__file__ = "fake_file.py"
-            
-            save_prompt_version(test_version, test_content)
-            
-            # Verify file was created with correct content
-            expected_file = temp_path / "quinn" / "templates" / "prompts" / f"system_{test_version}.txt"
-            assert expected_file.exists()
-            assert expected_file.read_text() == test_content
+        save_prompt_version(test_version, test_content, project_root=temp_path)
+
+        # Verify file was created with correct content
+        expected_file = (
+            temp_path / "quinn" / "templates" / "prompts" / f"system_{test_version}.txt"
+        )
+        assert expected_file.exists()
+        assert expected_file.read_text() == test_content
 
 
 def test_save_prompt_version_creates_directories() -> None:
     """Test that save_prompt_version creates necessary directories."""
-    import tempfile
-    from pathlib import Path
-    from unittest.mock import patch, MagicMock
-    
     test_content = "Test content"
     test_version = "240715-120000"
-    
+
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        
-        # Mock the Path(__file__).parent.parent.parent chain
-        mock_file_path = MagicMock()
-        mock_file_path.parent.parent.parent = temp_path
-        
-        with patch("quinn.agent.versioning.Path") as mock_path:
-            mock_path.return_value = mock_file_path
-            mock_path.__file__ = "fake_file.py"
-            
-            save_prompt_version(test_version, test_content)
-            
-            # Verify directories were created
-            prompts_dir = temp_path / "quinn" / "templates" / "prompts"
-            assert prompts_dir.exists()
-            assert prompts_dir.is_dir()
+        save_prompt_version(test_version, test_content, project_root=temp_path)
 
+        # Verify directories were created
+        prompts_dir = temp_path / "quinn" / "templates" / "prompts"
+        assert prompts_dir.exists()
+        assert prompts_dir.is_dir()
+
+
+def test_save_prompt_version_default_root(tmp_path: Path) -> None:
+    """Ensure default project root path is used when none is provided."""
+    mock_file_path = MagicMock()
+    mock_file_path.parent.parent.parent = tmp_path
+
+    with patch("quinn.agent.versioning.Path") as mock_path:
+        mock_path.return_value = mock_file_path
+        mock_path.__file__ = "ignored.py"
+
+        save_prompt_version("240715-120000", "data", project_root=None)
+
+    expected = tmp_path / "quinn" / "templates" / "prompts" / "system_240715-120000.txt"
+    assert expected.exists()
+    assert expected.read_text() == "data"
 
 
 def test_load_system_prompt_file_reading() -> None:
     """Test actual file reading in load_system_prompt."""
-    # This test will hit the actual file reading line
-    prompt = load_system_prompt()
-    assert isinstance(prompt, str)
-    assert len(prompt) > 0
+    test_content = "Actual prompt"
 
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        prompts_dir = root / "quinn" / "templates" / "prompts"
+        prompts_dir.mkdir(parents=True)
+        (prompts_dir / "system.txt").write_text(test_content)
+
+        result = load_system_prompt(project_root=root)
+        assert result == test_content
 
 
 def test_load_system_prompt_reads_real_file() -> None:
-    """Test that load_system_prompt reads from the actual file when it exists."""
-    # This should hit line 43: return prompt_file.read_text().strip()
-    # by reading the actual system.txt file
-    result = load_system_prompt()
-    assert isinstance(result, str)
-    assert len(result.strip()) > 0
+    """Test that load_system_prompt reads a version-specific prompt file."""
+    version = "240715-120000"
+    content = "Version specific"
 
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        dir_path = root / "quinn" / "templates" / "prompts"
+        dir_path.mkdir(parents=True)
+        (dir_path / f"system_{version}.txt").write_text(content)
+
+        loaded = load_system_prompt(version, project_root=root)
+        assert loaded == content


### PR DESCRIPTION
## Summary
- allow specifying `project_root` when loading or saving prompts
- streamline versioning tests and cover more branches
- add test ensuring default root is still used correctly

## Testing
- `make test-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882efe718b88324843880731ade5bd9