### PR TITLE
Fix database cleanup and treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ dev:  ## Run code quality checks (ruff, format, type check)
 test:  ## Run tests with last-failed first
 	uv run pytest
 
-test-coverage:  ## Run tests with coverage reporting
-	uv run pytest --cov=. --cov-report=html --cov-report=term --durations=5 
+test-coverage:  ## Run tests with coverage reporting and fail on warnings
+	uv run pytest -W error --cov=. --cov-report=html --cov-report=term --durations=5
 
 type-coverage:  ## Check type annotation coverage and quality
 	@echo "🔍 Checking type annotation coverage..."

--- a/quinn/db/conftest.py
+++ b/quinn/db/conftest.py
@@ -20,10 +20,13 @@ def temp_db() -> Generator[Path]:
 
     # Create tables in test database
     try:
-        with sqlite3.connect(db_file) as conn:
+        conn = sqlite3.connect(db_file)
+        try:
             with Path("quinn/db/schema.sql").open() as f:
                 conn.executescript(f.read())
             conn.commit()
+        finally:
+            conn.close()
     except Exception:
         # Clean up the file if database setup fails
         if db_file.exists():

--- a/quinn/email/outbound_test.py
+++ b/quinn/email/outbound_test.py
@@ -1,11 +1,13 @@
-import asyncio
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from quinn.email.outbound import format_reply, send_email
 from quinn.models.email import EmailDirection, EmailMessage
 
 
-async def _run_send() -> None:
+@pytest.mark.asyncio
+async def test_send_email() -> None:
     email = EmailMessage(
         id="<id1@pm>",
         from_email="q@example.com",
@@ -22,10 +24,6 @@ async def _run_send() -> None:
         mock_post.return_value.raise_for_status = lambda: None
         await send_email(email, "token")
         assert mock_post.call_args is not None
-
-
-def test_send_email() -> None:
-    asyncio.run(_run_send())
 
 
 def test_format_reply() -> None:


### PR DESCRIPTION
## Summary
- close database connection properly in test fixture
- convert async test to pytest style to avoid leftover event loop
- fail tests on any warnings via `-W error`

## Testing
- `make test-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882f0ffd258832483675494f1f0ead7